### PR TITLE
Availability Branch

### DIFF
--- a/fitblipper.py
+++ b/fitblipper.py
@@ -27,13 +27,17 @@
 import sys
 import re
 import bitarray
+import whois
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-l', help='list of all the FitBlipper possible with the domain', action="store_true")
+parser.add_argument('-a', help='list of all the available domains from the FitBlipper possibilities', action="store_true")
+args, domain = parser.parse_known_args()
 
 def main():
     if len(sys.argv) <= 1:
         print('You need to give me a string... or run --help for info')
-    elif sys.argv[1] == '--help':
-        print("FitBlipper is a utility to flip single bits in domain a string to see what combinations are possible.\n")
-        print("usage: fitblipper.py string_to_process")
     else:
         strang = sys.argv[1]
         tld = "com"
@@ -83,8 +87,17 @@ def main():
                     results[flipped_result_ascii] = flipped_result_ascii
         #print(bits.to01())
         #print(results.items())
-        for key, item in results.items():
-            print("%s.%s"  % (item, tld))
+        if args.l:
+            for key, item in results.items():
+                print("%s.%s"  % (item, tld))
+
+        if args.a:
+            for key, item in results.items():
+                #Check if a whois record exists for this domain
+                try: 
+                    domain = whois.whois("%s.%s"  % (item, tld))
+                except:
+                    print("%s.%s"  % (item, tld))
 
 if __name__ == '__main__':
     main()

--- a/fitblipper.py
+++ b/fitblipper.py
@@ -27,6 +27,7 @@
 import sys
 import re
 import bitarray
+import whois
 
 def main():
     if len(sys.argv) <= 1:
@@ -85,6 +86,14 @@ def main():
         #print(results.items())
         for key, item in results.items():
             print("%s.%s"  % (item, tld))
+
+        print("Following domain(s) are avaliable")
+        for key, item in results.items():
+            #Check if a whois record exists for this domain
+            try: 
+                domain = whois.whois("%s.%s"  % (item, tld))
+            except:
+                print("%s.%s"  % (item, tld))
 
 if __name__ == '__main__':
     main()

--- a/fitblipper.py
+++ b/fitblipper.py
@@ -99,13 +99,5 @@ def main():
                 except:
                     print("%s.%s"  % (item, tld))
 
-        print("Following domain(s) are avaliable")
-        for key, item in results.items():
-            #Check if a whois record exists for this domain
-            try: 
-                domain = whois.whois("%s.%s"  % (item, tld))
-            except:
-                print("%s.%s"  % (item, tld))
-
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I added the whois functionality internally using the ([whois module](https://pypi.python.org/pypi/python-whois))

and added flags to pass in case you want a list of the flipped bits, list of the available domains, or both.

```
usage: fitblipper.py domain [-h] [-l] [-a]
optional arguments:
  -h, --help  show this help message and exit
  -l          list of all the FitBlipper possible with the domain
  -a          list of all the available domains from the FitBlipper
              possibilities

```

While I did have some `Socket Error: [Errno 104] Connection reset by peer` when trying against google all the other domains I've tried have worked out well. Thanks for putting together the ground work for this script it really does help when I tell people about the hardware error of domain names.

(ps: if you get a chance I'm really looking forward to the HM malware code so I can learn more about RATs )
